### PR TITLE
Update lambdaworks revision

### DIFF
--- a/fibonacci_air_test_cases/case_1.cc
+++ b/fibonacci_air_test_cases/case_1.cc
@@ -43,7 +43,7 @@ int main() {
       /*log_n=*/log_coset_size + log_n_cosets,
       /*start_offset=*/fri_domain_offset);
 
-  size_t proof_of_work_bits = 0;
+  size_t proof_of_work_bits = 1;
   const std::vector<size_t> fri_step_list = {1, 1};
   size_t n_queries = 1;
   FriParameters fri_params{/*fri_step_list=*/fri_step_list,

--- a/fibonacci_air_test_cases/verify_from_bytes.cc
+++ b/fibonacci_air_test_cases/verify_from_bytes.cc
@@ -48,9 +48,9 @@ int main(int argc, char *argv[]) {
       /*log_n=*/log_coset_size + log_n_cosets,
       /*start_offset=*/fri_domain_offset);
 
-  size_t proof_of_work_bits = 9;
+  size_t proof_of_work_bits = 20;
   const std::vector<size_t> fri_step_list = {1, 1, 1, 1, 1, 1, 1, 1, 1};
-  size_t n_queries = 1;
+  size_t n_queries = 200;
   FriParameters fri_params{/*fri_step_list=*/fri_step_list,
                            /*last_layer_degree_bound=*/1,
                            /*n_queries=*/n_queries,

--- a/fibonacci_air_test_cases/verify_from_bytes.cc
+++ b/fibonacci_air_test_cases/verify_from_bytes.cc
@@ -33,23 +33,23 @@ int main(int argc, char *argv[]) {
   const Field field(Field::Create<FieldElementT>());
 
   // AIR
-  uint64_t trace_length = 4;
-  uint64_t fibonacci_claim_index = 3;
+  uint64_t trace_length = 512;
+  uint64_t fibonacci_claim_index = 501;
   StarkField252Element secret = StarkField252Element::One();
   StarkField252Element claimed_fib =
       FibAirT::PublicInputFromPrivateInput(secret, fibonacci_claim_index);
   auto air = FibAirT(trace_length, fibonacci_claim_index, claimed_fib);
 
   // FRI configuration
-  const auto log_n_cosets = 2;
+  const auto log_n_cosets = 3;
   const size_t log_coset_size = Log2Ceil(trace_length);
   const FieldElementT fri_domain_offset = FieldElementT::FromUint(3);
   FftBasesImpl<FftMultiplicativeGroup<FieldElementT>> fft_bases = MakeFftBases(
       /*log_n=*/log_coset_size + log_n_cosets,
       /*start_offset=*/fri_domain_offset);
 
-  size_t proof_of_work_bits = 0;
-  const std::vector<size_t> fri_step_list = {1, 1};
+  size_t proof_of_work_bits = 9;
+  const std::vector<size_t> fri_step_list = {1, 1, 1, 1, 1, 1, 1, 1, 1};
   size_t n_queries = 1;
   FriParameters fri_params{/*fri_step_list=*/fri_step_list,
                            /*last_layer_degree_bound=*/1,

--- a/fibonacci_air_test_cases/verify_from_bytes.cc
+++ b/fibonacci_air_test_cases/verify_from_bytes.cc
@@ -29,6 +29,18 @@ MakeTableProver(uint64_t n_segments, uint64_t n_rows_per_segment,
       n_segments, n_rows_per_segment, n_columns);
 }
 
+template <typename FieldElementT>
+std::vector<std::byte> GetInitialHashChainSeed(uint64_t fibonacci_claim_index, FieldElementT *claimed_fib) {
+  const size_t elem_bytes = FieldElementT::SizeInBytes();
+  const size_t fibonacci_claim_index_bytes = sizeof(uint64_t);
+  std::vector<std::byte> randomness_seed(elem_bytes + fibonacci_claim_index_bytes);
+  Serialize(
+      uint64_t(fibonacci_claim_index),
+      gsl::make_span(randomness_seed).subspan(0, fibonacci_claim_index_bytes));
+  (*claimed_fib).ToBytes(gsl::make_span(randomness_seed).subspan(fibonacci_claim_index_bytes));
+  return randomness_seed;
+}
+
 int main(int argc, char *argv[]) {
   const Field field(Field::Create<FieldElementT>());
 
@@ -57,7 +69,7 @@ int main(int argc, char *argv[]) {
                            /*fft_bases=*/UseOwned(&fft_bases),
                            /*field=*/field,
                            /*proof_of_work_bits=*/proof_of_work_bits};
-  const Prng channel_prng = Prng(MakeByteArray<0xca, 0xfe, 0xca, 0xfe>());
+  const Prng channel_prng = Prng(GetInitialHashChainSeed(fibonacci_claim_index, &claimed_fib));
   NoninteractiveProverChannel prover_channel =
       NoninteractiveProverChannel(channel_prng.Clone());
 

--- a/lambdaworks_prover/Cargo.toml
+++ b/lambdaworks_prover/Cargo.toml
@@ -10,5 +10,7 @@ path = "src/main.rs"
 [features]
 
 [dependencies]
-lambdaworks-math = { git = "https://github.com/lambdaclass/lambdaworks", rev="2cefa61eb50a26c5cd83a7f89f569673d0acea2b"}
-stark-platinum-prover = {git = "https://github.com/lambdaclass/lambdaworks", rev="2cefa61eb50a26c5cd83a7f89f569673d0acea2b"}
+lambdaworks-math = { git = "https://github.com/lambdaclass/lambdaworks", rev="e712f1dad0439"}
+stark-platinum-prover = {git = "https://github.com/lambdaclass/lambdaworks", rev="e712f1dad0439"}
+
+

--- a/lambdaworks_prover/Cargo.toml
+++ b/lambdaworks_prover/Cargo.toml
@@ -10,7 +10,8 @@ path = "src/main.rs"
 [features]
 
 [dependencies]
-lambdaworks-math = { git = "https://github.com/lambdaclass/lambdaworks", rev="e712f1dad0439"}
-stark-platinum-prover = {git = "https://github.com/lambdaclass/lambdaworks", rev="e712f1dad0439"}
+lambdaworks-math = { git = "https://github.com/lambdaclass/lambdaworks", rev="62e3c80d613e15"}
+stark-platinum-prover = {git = "https://github.com/lambdaclass/lambdaworks", rev="62e3c80d613e15"}
+
 
 

--- a/lambdaworks_prover/Cargo.toml
+++ b/lambdaworks_prover/Cargo.toml
@@ -10,5 +10,5 @@ path = "src/main.rs"
 [features]
 
 [dependencies]
-lambdaworks-math = { git = "https://github.com/lambdaclass/lambdaworks", rev="255cd8650db0626e595afcd0ca6cc4069a07cc5a"}
-stark-platinum-prover = {git = "https://github.com/lambdaclass/lambdaworks", rev="255cd8650db0626e595afcd0ca6cc4069a07cc5a"}
+lambdaworks-math = { git = "https://github.com/lambdaclass/lambdaworks", rev="2cefa61eb50a26c5cd83a7f89f569673d0acea2b"}
+stark-platinum-prover = {git = "https://github.com/lambdaclass/lambdaworks", rev="2cefa61eb50a26c5cd83a7f89f569673d0acea2b"}

--- a/lambdaworks_prover/src/main.rs
+++ b/lambdaworks_prover/src/main.rs
@@ -14,11 +14,12 @@ fn main() {
 
     let claimed_index = 501;
     let claimed_value = trace.get_row(claimed_index)[0];
-    let mut proof_options = ProofOptions::default_test_options();
-    proof_options.blowup_factor = 8;
-    proof_options.coset_offset = 3;
-    proof_options.grinding_factor = 9;
-    proof_options.fri_number_of_queries = 1;
+    let proof_options = ProofOptions {
+        blowup_factor: 8,
+        coset_offset: 3,
+        grinding_factor: 20,
+        fri_number_of_queries: 200,
+    };
 
     let pub_inputs = fibonacci_2_cols_shifted::PublicInputs {
         claimed_value,

--- a/lambdaworks_prover/src/main.rs
+++ b/lambdaworks_prover/src/main.rs
@@ -10,14 +10,14 @@ use stark_platinum_prover::transcript::StoneProverTranscript;
 use lambdaworks_math::traits::Serializable;
 
 fn main() {
-    let trace = fibonacci_2_cols_shifted::compute_trace(FieldElement::one(), 4);
+    let trace = fibonacci_2_cols_shifted::compute_trace(FieldElement::one(), 512);
 
-    let claimed_index = 3;
+    let claimed_index = 501;
     let claimed_value = trace.get_row(claimed_index)[0];
     let mut proof_options = ProofOptions::default_test_options();
-    proof_options.blowup_factor = 4;
+    proof_options.blowup_factor = 8;
     proof_options.coset_offset = 3;
-    proof_options.grinding_factor = 0;
+    proof_options.grinding_factor = 9;
     proof_options.fri_number_of_queries = 1;
 
     let pub_inputs = fibonacci_2_cols_shifted::PublicInputs {

--- a/lambdaworks_prover/src/main.rs
+++ b/lambdaworks_prover/src/main.rs
@@ -4,6 +4,7 @@ use std::io::Write;
 use stark_platinum_prover::examples::fibonacci_2_cols_shifted::{self, Fibonacci2ColsShifted};
 use stark_platinum_prover::fri::FieldElement;
 use stark_platinum_prover::proof::options::ProofOptions;
+use stark_platinum_prover::proof::stark::StoneCompatibleSerializer;
 use stark_platinum_prover::prover::{IsStarkProver, Prover};
 use stark_platinum_prover::transcript::StoneProverTranscript;
 
@@ -36,6 +37,11 @@ fn main() {
         StoneProverTranscript::new(&transcript_init_seed),
     )
     .unwrap();
+    let serialized_proof = StoneCompatibleSerializer::serialize::<Fibonacci2ColsShifted<_>>(
+        &proof,
+        &pub_inputs,
+        &proof_options,
+    );
     let mut file = File::create("lambdaworks_proof.bin").unwrap();
-    let _ = file.write_all(&proof.serialize());
+    let _ = file.write_all(&serialized_proof);
 }

--- a/lambdaworks_prover/src/main.rs
+++ b/lambdaworks_prover/src/main.rs
@@ -26,7 +26,8 @@ fn main() {
         claimed_index,
     };
 
-    let transcript_init_seed = [0xca, 0xfe, 0xca, 0xfe];
+    let mut transcript_init_seed = claimed_index.to_be_bytes().to_vec();
+    transcript_init_seed.extend_from_slice(&claimed_value.serialize());
 
     let proof = Prover::prove::<Fibonacci2ColsShifted<_>>(
         &trace,


### PR DESCRIPTION
This PR updates lambdaworks revision to include the new serializer API. It also increases the parameters of the test to include multiple queries, a larger trace. The transcript is initialized using the strong Fiat Shamir strategy of the Fibonacci statement.